### PR TITLE
fix(product): getVendusPrices() returns non-existent $this->s property

### DIFF
--- a/src/Traits/InteractsWithVendusProduct.php
+++ b/src/Traits/InteractsWithVendusProduct.php
@@ -79,7 +79,7 @@ trait InteractsWithVendusProduct
      */
     public function getVendusSupplyPrice(): float
     {
-        return $this->supply_price ?? '';
+        return $this->supply_price ?? 0.0;
     }
 
     /**
@@ -87,7 +87,7 @@ trait InteractsWithVendusProduct
      */
     public function getVendusGrossPrice(): float
     {
-        return $this->gross_price ?? '';
+        return $this->gross_price ?? 0.0;
     }
 
     /**
@@ -193,7 +193,7 @@ trait InteractsWithVendusProduct
      */
     public function getVendusPrices(): array
     {
-        return $this->s ?? [];
+        return $this->prices ?? [];
 
     }
 

--- a/src/Traits/InteractsWithVendusProduct.php
+++ b/src/Traits/InteractsWithVendusProduct.php
@@ -79,7 +79,7 @@ trait InteractsWithVendusProduct
      */
     public function getVendusSupplyPrice(): float
     {
-        return $this->supply_price ?? 0.0;
+        return (float) ($this->supply_price ?? 0);
     }
 
     /**
@@ -87,7 +87,7 @@ trait InteractsWithVendusProduct
      */
     public function getVendusGrossPrice(): float
     {
-        return $this->gross_price ?? 0.0;
+        return (float) ($this->gross_price ?? 0);
     }
 
     /**


### PR DESCRIPTION
## Description

`getVendusPrices()` in `InteractsWithVendusProduct` returned `$this->s ?? []` — a property that never exists — so product price groups were silently never sent to Vendus. It now returns `$this->prices ?? []`.

While auditing the remaining getters (second task of the issue), `getVendusSupplyPrice()` and `getVendusGrossPrice()` were found falling back to `''` despite their `float` return type, which throws a `TypeError` for any model without those attributes. Both now default to `0.0`.

A regression test will land with the v2 test-suite issues (#8/#9).

Fixes #4
