### PR TITLE
chore(repo): normalize line endings and tighten repo hygiene

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto eol=lf
+
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.idea export-ignore
+/art export-ignore
+/docs export-ignore
+/tests export-ignore
+/phpunit.xml export-ignore
+/phpstan.neon export-ignore
+/pint.json export-ignore
+/testbench.yaml export-ignore
+/.env.example export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /.idea
+/vendor
+/.phpunit.cache
+composer.lock
+.env
+.env.backup


### PR DESCRIPTION
## Description

- Adds `.gitattributes` with `* text=auto eol=lf` — this stops the LF→CRLF working-tree churn on Windows/WSL that was showing all 22 tracked files as modified — plus `export-ignore` rules so dev files (CI, tests, art, docs, tooling configs) are stripped from the Composer dist tarball. Entries for files landing later in the v2 cycle (`tests/`, `phpunit.xml`, `pint.json`, …) are included up front.
- Extends `.gitignore` with `/vendor`, `composer.lock`, `/.phpunit.cache`, `.env` and `.env.backup`, matching the laravel-eupago template. `.idea/` was already ignored and untracked.
- `git add --renormalize .` produced no changes — the repository content was already LF throughout.

Fixes #6
