### PR TITLE
feat(laravel)!: require PHP ^8.2 and add support for Laravel 11 to 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,19 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.3|^8.0",
-    "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+    "php": "^8.2",
+    "illuminate/support": "^11.0|^12.0|^13.0",
     "codetech/vendus-api": "^1.1.0"
+  },
+  "config": {
+    "sort-packages": true
   },
   "autoload": {
     "psr-4": {
       "CodeTech\\Vendus\\": "src/"
     }
   },
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "prefer-stable": true,
   "extra": {
     "laravel": {

--- a/src/Providers/VendusServiceProvider.php
+++ b/src/Providers/VendusServiceProvider.php
@@ -45,7 +45,7 @@ class VendusServiceProvider extends ServiceProvider
     private function setPublishableFiles()
     {
         $this->publishes([
-            __DIR__ . '/../../resources/lang' => resource_path('lang/vendor/vendus'),
+            __DIR__ . '/../../resources/lang' => $this->app->langPath('vendor/vendus'),
         ], 'translations');
 
         $this->publishes([


### PR DESCRIPTION
## Description

Core platform bump of the v2.0.0 milestone — breaking change:

- `php` `^7.3|^8.0` → `^8.2`; `illuminate/support` `^6.0–^10.0` → `^11.0|^12.0|^13.0`
- `minimum-stability` `dev` → `stable` (keeping `prefer-stable`) and `config.sort-packages: true`, aligning with laravel-eupago
- `codetech/vendus-api ^1.1` stays for now — its `^7.3|^8.0` constraint installs fine alongside PHP 8.2+; it is removed later in the cycle by the client absorption (#17). Dependency resolution verified with `composer update --dry-run` on PHP 8.4 / Laravel 13
- src/ review for Laravel 11+ compatibility: the service provider uses only current APIs; the one fix needed was the translations publish target, which still pointed at the pre-Laravel-9 `resources/lang` location — now `$this->app->langPath('vendor/vendus')`

Fixes #7
