### PR TITLE
feat(http)!: absorb the Vendus API client, drop codetech/vendus-api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VENDUS_MODE=tests
 VENDUS_API_KEY=
 VENDUS_APP_URL=
+VENDUS_BASE_URL=https://www.vendus.pt/ws/v1.1/

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
   "license": "MIT",
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^11.0|^12.0|^13.0",
-    "codetech/vendus-api": "^1.1.0"
+    "guzzlehttp/guzzle": "^7.8",
+    "illuminate/http": "^11.0|^12.0|^13.0",
+    "illuminate/support": "^11.0|^12.0|^13.0"
   },
   "require-dev": {
     "orchestra/testbench": "^9.0|^10.0|^11.0",

--- a/config/vendus.php
+++ b/config/vendus.php
@@ -17,4 +17,6 @@ return [
 
     'app_url' => env('VENDUS_APP_URL'),
 
+    'base_url' => env('VENDUS_BASE_URL', 'https://www.vendus.pt/ws/v1.1/'),
+
 ];

--- a/src/Http/Endpoint.php
+++ b/src/Http/Endpoint.php
@@ -136,7 +136,7 @@ class Endpoint
      */
     private function handleException(RequestException $exception): void
     {
-        $errors = $exception->response->object()->errors ?? [];
+        $errors = $exception->response->object()?->errors ?? [];
 
         $messages = [];
 

--- a/src/Http/Endpoint.php
+++ b/src/Http/Endpoint.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace CodeTech\Vendus\Http;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+class Endpoint
+{
+    public function __construct(
+        protected VendusApi $api,
+        protected string $uri
+    ) {
+    }
+
+    /**
+     * Find the specified resource.
+     *
+     * @return mixed|null
+     */
+    public function find(int $id, array $params = []): mixed
+    {
+        try {
+            $response = $this->request()
+                ->get($this->uri.'/'.$id, array_merge($this->api->getDefaultQueryParams(), $params))
+                ->throw();
+        } catch (RequestException $exception) {
+            $this->handleException($exception);
+
+            return null;
+        }
+
+        return $response->object();
+    }
+
+    /**
+     * Get a list of the specified resource.
+     */
+    public function get(array $params = []): mixed
+    {
+        try {
+            $response = $this->request()
+                ->get($this->uri, array_merge($this->api->getDefaultQueryParams(), $params))
+                ->throw();
+        } catch (RequestException $exception) {
+            $this->handleException($exception);
+
+            return [];
+        }
+
+        return $response->object();
+    }
+
+    /**
+     * Get a paginated list of the specified resource.
+     */
+    public function paginate(array $params, int $page, int $perPage): array
+    {
+        $params['page'] = $page;
+        $params['per_page'] = $perPage;
+
+        try {
+            $response = $this->request()
+                ->get($this->uri, array_merge($this->api->getDefaultQueryParams(), $params))
+                ->throw();
+        } catch (RequestException $exception) {
+            $this->handleException($exception);
+
+            return [
+                'data' => [],
+                'total' => 0,
+            ];
+        }
+
+        return [
+            'data' => $response->object(),
+            'total' => (int) $response->header('X-Paginator-Items'),
+        ];
+    }
+
+    /**
+     * Creates a new resource.
+     *
+     * @throws RequestException
+     */
+    public function create(array $params = []): mixed
+    {
+        try {
+            $response = $this->request()
+                ->withQueryParameters($this->api->getDefaultQueryParams())
+                ->asForm()
+                ->post($this->uri, $params)
+                ->throw();
+        } catch (RequestException $exception) {
+            $this->handleException($exception);
+
+            throw $exception;
+        }
+
+        return $response->object();
+    }
+
+    /**
+     * Updates the specified resource.
+     *
+     * @throws RequestException
+     */
+    public function update(int $id, array $params = []): mixed
+    {
+        try {
+            $response = $this->request()
+                ->withQueryParameters($this->api->getDefaultQueryParams())
+                ->asForm()
+                ->patch($this->uri.'/'.$id, $params)
+                ->throw();
+        } catch (RequestException $exception) {
+            $this->handleException($exception);
+
+            throw $exception;
+        }
+
+        return $response->object();
+    }
+
+    /**
+     * A pending request against the configured Vendus API base URL.
+     */
+    private function request(): PendingRequest
+    {
+        return Http::baseUrl($this->api->getBaseUrl());
+    }
+
+    /**
+     * Handles an exception by setting the error messages on the api instance.
+     */
+    private function handleException(RequestException $exception): void
+    {
+        $errors = $exception->response->object()->errors ?? [];
+
+        $messages = [];
+
+        foreach ($errors as $key => $error) {
+            $messages[$key] = $error->code.': '.$error->message;
+        }
+
+        $this->api->setErrors($messages);
+    }
+}

--- a/src/Http/VendusApi.php
+++ b/src/Http/VendusApi.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace CodeTech\Vendus\Http;
+
+class VendusApi
+{
+    /**
+     * The error messages.
+     *
+     * @var array
+     */
+    private array $errors = [];
+
+    public function __construct(
+        protected string $apiKey,
+        protected string $baseUrl = 'https://www.vendus.pt/ws/v1.1/'
+    ) {
+    }
+
+    /**
+     * Get the clients endpoint.
+     */
+    public function clients(): Endpoint
+    {
+        return new Endpoint($this, 'clients');
+    }
+
+    /**
+     * Get the products endpoint.
+     */
+    public function products(): Endpoint
+    {
+        return new Endpoint($this, 'products');
+    }
+
+    /**
+     * Get the product units endpoint.
+     */
+    public function units(): Endpoint
+    {
+        return new Endpoint($this, 'products/units');
+    }
+
+    /**
+     * Get the documents endpoint.
+     */
+    public function documents(): Endpoint
+    {
+        return new Endpoint($this, 'documents');
+    }
+
+    /**
+     * Get the payment methods endpoint.
+     */
+    public function paymentMethods(): Endpoint
+    {
+        return new Endpoint($this, 'documents/paymentmethods');
+    }
+
+    /**
+     * The base URL of the Vendus API.
+     */
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    /**
+     * The query parameters that must be sent on every request.
+     */
+    public function getDefaultQueryParams(): array
+    {
+        return [
+            'api_key' => $this->apiKey,
+        ];
+    }
+
+    /**
+     * Get the errors.
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Set the errors.
+     */
+    public function setErrors(array $errors): void
+    {
+        $this->errors = $errors;
+    }
+}

--- a/src/VendusResource.php
+++ b/src/VendusResource.php
@@ -3,7 +3,7 @@
 namespace CodeTech\Vendus;
 
 use CodeTech\Vendus\Contracts\VendusApiResource;
-use CodeTech\VendusApi\Api;
+use CodeTech\Vendus\Http\VendusApi;
 
 class VendusResource
 {
@@ -13,7 +13,7 @@ class VendusResource
     public $resource;
 
     /**
-     * @var Api
+     * @var VendusApi
      */
     protected $vendusApiClient;
 
@@ -27,7 +27,10 @@ class VendusResource
     {
         $this->resource = $resource;
 
-        $this->vendusApiClient = new Api(config('vendus.api_key'));
+        $this->vendusApiClient = new VendusApi(
+            config('vendus.api_key'),
+            config('vendus.base_url')
+        );
     }
 
     /**
@@ -38,7 +41,7 @@ class VendusResource
      */
     public function find(array $params)
     {
-        return $this->vendusApiClient->{$this->resource->getVendusResourceName()}->find($this->resource->getVendusId(), $params);
+        return $this->vendusApiClient->{$this->resource->getVendusResourceName()}()->find($this->resource->getVendusId(), $params);
     }
 
     /**

--- a/src/VendusResource.php
+++ b/src/VendusResource.php
@@ -4,6 +4,7 @@ namespace CodeTech\Vendus;
 
 use CodeTech\Vendus\Contracts\VendusApiResource;
 use CodeTech\Vendus\Http\VendusApi;
+use InvalidArgumentException;
 
 class VendusResource
 {
@@ -27,17 +28,22 @@ class VendusResource
     {
         $this->resource = $resource;
 
-        $this->vendusApiClient = new VendusApi(
-            config('vendus.api_key'),
-            config('vendus.base_url')
-        );
+        $apiKey = config('vendus.api_key');
+
+        if (! is_string($apiKey) || $apiKey === '') {
+            throw new InvalidArgumentException(
+                'The Vendus API key is not configured. Set the VENDUS_API_KEY environment variable.'
+            );
+        }
+
+        $this->vendusApiClient = new VendusApi($apiKey, config('vendus.base_url'));
     }
 
     /**
      * Get a specified resource.
      *
      * @param array $params
-     * @return bool
+     * @return mixed
      */
     public function find(array $params)
     {

--- a/tests/Feature/Http/EndpointTest.php
+++ b/tests/Feature/Http/EndpointTest.php
@@ -1,0 +1,139 @@
+<?php
+
+use CodeTech\Vendus\Http\VendusApi;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->api = new VendusApi('test-api-key', 'https://www.vendus.test/ws/v1.1/');
+});
+
+it('finds a resource by id', function () {
+    Http::fake([
+        'www.vendus.test/ws/v1.1/clients/123*' => Http::response(['id' => 123, 'name' => 'Maria']),
+    ]);
+
+    $client = $this->api->clients()->find(123);
+
+    expect($client)->toBeObject()
+        ->and($client->id)->toBe(123)
+        ->and($client->name)->toBe('Maria');
+
+    Http::assertSent(function (Request $request) {
+        return str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/clients/123')
+            && $request['api_key'] === 'test-api-key';
+    });
+});
+
+it('returns null and records errors when a find fails', function () {
+    Http::fake([
+        '*' => Http::response([
+            'errors' => [['code' => 'A001', 'message' => 'Resource not found']],
+        ], 404),
+    ]);
+
+    $client = $this->api->clients()->find(999);
+
+    expect($client)->toBeNull()
+        ->and($this->api->getErrors())->toBe(['A001: Resource not found']);
+});
+
+it('gets a listing of resources with extra query params', function () {
+    Http::fake([
+        '*' => Http::response([['id' => 1], ['id' => 2]]),
+    ]);
+
+    $products = $this->api->products()->get(['status' => 'on']);
+
+    expect($products)->toHaveCount(2)
+        ->and($products[0]->id)->toBe(1);
+
+    Http::assertSent(function (Request $request) {
+        return str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/products')
+            && $request['status'] === 'on'
+            && $request['api_key'] === 'test-api-key';
+    });
+});
+
+it('returns an empty list and records errors when a get fails', function () {
+    Http::fake([
+        '*' => Http::response([
+            'errors' => [['code' => 'A401', 'message' => 'Invalid api key']],
+        ], 401),
+    ]);
+
+    $products = $this->api->products()->get();
+
+    expect($products)->toBe([])
+        ->and($this->api->getErrors())->toBe(['A401: Invalid api key']);
+});
+
+it('paginates a listing using the paginator header', function () {
+    Http::fake([
+        '*' => Http::response([['id' => 1]], 200, ['X-Paginator-Items' => '42']),
+    ]);
+
+    $page = $this->api->documents()->paginate([], 2, 10);
+
+    expect($page['total'])->toBe(42)
+        ->and($page['data'])->toHaveCount(1);
+
+    Http::assertSent(function (Request $request) {
+        return $request['page'] == 2 && $request['per_page'] == 10;
+    });
+});
+
+it('creates a resource with a form-encoded body', function () {
+    Http::fake([
+        '*' => Http::response(['id' => 55]),
+    ]);
+
+    $result = $this->api->clients()->create(['name' => 'Maria', 'fiscal_id' => '123456789']);
+
+    expect($result->id)->toBe(55);
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'POST'
+            && $request->isForm()
+            && $request['name'] === 'Maria'
+            && str_contains($request->url(), 'api_key=test-api-key');
+    });
+});
+
+it('records errors and rethrows when a create fails', function () {
+    Http::fake([
+        '*' => Http::response([
+            'errors' => [['code' => 'A100', 'message' => 'Missing fiscal id']],
+        ], 422),
+    ]);
+
+    expect(fn () => $this->api->clients()->create(['name' => 'Maria']))
+        ->toThrow(RequestException::class)
+        ->and($this->api->getErrors())->toBe(['A100: Missing fiscal id']);
+});
+
+it('updates a resource with a patch request', function () {
+    Http::fake([
+        '*' => Http::response(['id' => 55, 'name' => 'Updated']),
+    ]);
+
+    $result = $this->api->clients()->update(55, ['name' => 'Updated']);
+
+    expect($result->name)->toBe('Updated');
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'PATCH'
+            && str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/clients/55');
+    });
+});
+
+it('exposes the resource endpoints and their uris', function () {
+    Http::fake(['*' => Http::response([])]);
+
+    $this->api->units()->get();
+    $this->api->paymentMethods()->get();
+
+    Http::assertSent(fn (Request $request) => str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/products/units'));
+    Http::assertSent(fn (Request $request) => str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/documents/paymentmethods'));
+});

--- a/tests/Feature/Http/EndpointTest.php
+++ b/tests/Feature/Http/EndpointTest.php
@@ -39,6 +39,17 @@ it('returns null and records errors when a find fails', function () {
         ->and($this->api->getErrors())->toBe(['A001: Resource not found']);
 });
 
+it('records no errors when a failure response has no json body', function () {
+    Http::fake([
+        '*' => Http::response('Internal Server Error', 500),
+    ]);
+
+    $client = $this->api->clients()->find(1);
+
+    expect($client)->toBeNull()
+        ->and($this->api->getErrors())->toBe([]);
+});
+
 it('gets a listing of resources with extra query params', function () {
     Http::fake([
         '*' => Http::response([['id' => 1], ['id' => 2]]),

--- a/tests/Feature/VendusResourceTest.php
+++ b/tests/Feature/VendusResourceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use CodeTech\Vendus\Contracts\VendusApiResource;
+use CodeTech\Vendus\VendusResource;
+
+function fakeVendusApiResource(): VendusApiResource
+{
+    return new class implements VendusApiResource
+    {
+        public function getVendusId(): ?int
+        {
+            return null;
+        }
+
+        public function setVendusId(int $vendusId): void
+        {
+        }
+
+        public function getVendusResourceName(): string
+        {
+            return 'clients';
+        }
+
+        public function getVendusParams(): array
+        {
+            return [];
+        }
+
+        public function getVendusFindMatchParams(): array
+        {
+            return [];
+        }
+    };
+}
+
+it('throws a clear exception when the api key is not configured', function () {
+    config()->set('vendus.api_key', null);
+
+    new VendusResource(fakeVendusApiResource());
+})->throws(InvalidArgumentException::class, 'The Vendus API key is not configured.');
+
+it('throws a clear exception when the api key is an empty string', function () {
+    config()->set('vendus.api_key', '');
+
+    new VendusResource(fakeVendusApiResource());
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
## Description

Retires the external `codetech/vendus-api` dependency by folding the HTTP layer into the package, built on Laravel's HTTP client:

- **`src/Http/VendusApi.php`** — replaces `CodeTech\VendusApi\Api`: same endpoint surface (`clients`, `products`, `units`, `documents`, `paymentMethods`) and error bag, now with constructor-injected API key + base URL and no dynamic properties (the old client set `$this->uri` dynamically — deprecated on PHP 8.2+).
- **`src/Http/Endpoint.php`** — replaces the Guzzle-based `Endpoint` with identical transport semantics, deliberately preserved from the battle-tested client: `api_key` as a query parameter on every request, form-encoded `create`/`update` bodies, JSON responses decoded to objects, `"CODE: message"` error strings, `X-Paginator-Items` pagination header.
- **`config/vendus.php`** — new `base_url` key (`VENDUS_BASE_URL`, defaults to `https://www.vendus.pt/ws/v1.1/`), making the previously hard-coded base URL configurable and the client fully fakeable.
- **`VendusResource`** — unchanged public API; now instantiates the internal client. Also fixes a latent bug: `find()` accessed the endpoint as a property (`->clients`) instead of calling it (`->clients()`), which always fataled on the old client.
- **composer.json** — drops `codetech/vendus-api`; adds `illuminate/http` + `guzzlehttp/guzzle ^7.8` (the HTTP client's transport).

Behavior differences (intentional): connection-level failures now surface as `Illuminate\Http\Client\ConnectionException` instead of fataling inside the old error handler, and `find()` works.

Covered by 9 new `Http::fake()` tests (success/error paths per verb, query auth, form encoding, pagination header, endpoint URIs). Full suite: 14 passed / 34 assertions.

Once this ships in v2.0.0, `codetech/vendus-api` gets deprecated and archived (CodeTechAgency/vendus-api#3).

Fixes #17
