### PR TITLE
test(coverage): cover VendusResource, traits and entities

### DIFF
--- a/tests/Feature/VendusResourceTest.php
+++ b/tests/Feature/VendusResourceTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use CodeTech\Vendus\Contracts\VendusApiResource;
+use CodeTech\Vendus\Tests\Fixtures\Client;
 use CodeTech\Vendus\VendusResource;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
 
 function fakeVendusApiResource(): VendusApiResource
 {
@@ -44,3 +48,122 @@ it('throws a clear exception when the api key is an empty string', function () {
 
     new VendusResource(fakeVendusApiResource());
 })->throws(InvalidArgumentException::class);
+
+it('stores a new resource on vendus and links it locally', function () {
+    Http::fake(function (Request $request) {
+        return $request->method() === 'GET'
+            ? Http::response([])
+            : Http::response(['id' => 987, 'name' => 'Maria']);
+    });
+
+    $client = Client::create(['name' => 'Maria', 'fiscal_id' => '123456789']);
+
+    $result = (new VendusResource($client))->store();
+
+    expect($result)->toBe(['id' => 987, 'name' => 'Maria'])
+        ->and($client->fresh()->vendus_id)->toBe(987);
+
+    Http::assertSent(function (Request $request) use ($client) {
+        return $request->method() === 'GET'
+            && $request['external_reference'] == $client->id;
+    });
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'POST'
+            && str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/clients')
+            && $request['name'] === 'Maria';
+    });
+});
+
+it('links and updates when the resource already exists on vendus', function () {
+    Http::fake(function (Request $request) {
+        return $request->method() === 'GET'
+            ? Http::response([['id' => 555]])
+            : Http::response(['id' => 555, 'name' => 'Maria']);
+    });
+
+    $client = Client::create(['name' => 'Maria']);
+
+    $result = (new VendusResource($client))->store();
+
+    expect($result['id'])->toBe(555)
+        ->and($client->fresh()->vendus_id)->toBe(555);
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'PATCH'
+            && str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/clients/555');
+    });
+    Http::assertNotSent(fn (Request $request) => $request->method() === 'POST');
+});
+
+it('syncs by storing when the model has no vendus id', function () {
+    Http::fake(function (Request $request) {
+        return $request->method() === 'GET'
+            ? Http::response([])
+            : Http::response(['id' => 987]);
+    });
+
+    $client = Client::create(['name' => 'Maria']);
+
+    (new VendusResource($client))->sync();
+
+    expect($client->fresh()->vendus_id)->toBe(987);
+    Http::assertSent(fn (Request $request) => $request->method() === 'POST');
+});
+
+it('syncs by updating when the model already has a vendus id', function () {
+    Http::fake(['*' => Http::response(['id' => 321, 'name' => 'Updated'])]);
+
+    $client = Client::create(['name' => 'Maria', 'vendus_id' => 321]);
+
+    $result = (new VendusResource($client))->sync();
+
+    expect($result)->toBe(['id' => 321, 'name' => 'Updated']);
+
+    Http::assertSent(function (Request $request) {
+        return $request->method() === 'PATCH'
+            && str_starts_with($request->url(), 'https://www.vendus.test/ws/v1.1/clients/321');
+    });
+    Http::assertNotSent(fn (Request $request) => $request->method() === 'POST');
+});
+
+it('propagates creation errors and keeps the model unlinked', function () {
+    Http::fake(function (Request $request) {
+        return $request->method() === 'GET'
+            ? Http::response([])
+            : Http::response(['errors' => [['code' => 'A100', 'message' => 'Missing fiscal id']]], 422);
+    });
+
+    $client = Client::create(['name' => 'Maria']);
+    $resource = new VendusResource($client);
+
+    expect(fn () => $resource->store())->toThrow(RequestException::class)
+        ->and($resource->getErrors())->toBe(['A100: Missing fiscal id'])
+        ->and($client->fresh()->vendus_id)->toBeNull();
+});
+
+it('finds the linked resource on vendus', function () {
+    Http::fake(['*' => Http::response(['id' => 5, 'name' => 'Maria'])]);
+
+    $client = Client::create(['name' => 'Maria', 'vendus_id' => 5]);
+
+    $found = (new VendusResource($client))->find([]);
+
+    expect($found->id)->toBe(5);
+
+    Http::assertSent(fn (Request $request) => str_starts_with(
+        $request->url(),
+        'https://www.vendus.test/ws/v1.1/clients/5'
+    ));
+});
+
+it('gets a listing of the resource from vendus', function () {
+    Http::fake(['*' => Http::response([['id' => 1], ['id' => 2]])]);
+
+    $client = Client::create(['name' => 'Maria']);
+
+    $results = (new VendusResource($client))->get(['status' => 'active']);
+
+    expect($results)->toHaveCount(2);
+
+    Http::assertSent(fn (Request $request) => $request['status'] === 'active');
+});

--- a/tests/Fixtures/Client.php
+++ b/tests/Fixtures/Client.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CodeTech\Vendus\Tests\Fixtures;
+
+use CodeTech\Vendus\Contracts\VendusClient;
+use CodeTech\Vendus\Traits\InteractsWithVendusClient;
+use Illuminate\Database\Eloquent\Model;
+
+class Client extends Model implements VendusClient
+{
+    use InteractsWithVendusClient;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'price_group' => 'array',
+    ];
+}

--- a/tests/Fixtures/Product.php
+++ b/tests/Fixtures/Product.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace CodeTech\Vendus\Tests\Fixtures;
+
+use CodeTech\Vendus\Contracts\VendusProduct;
+use CodeTech\Vendus\Traits\InteractsWithVendusProduct;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model implements VendusProduct
+{
+    use InteractsWithVendusProduct;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'prices' => 'array',
+    ];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,8 @@
 namespace CodeTech\Vendus\Tests;
 
 use CodeTech\Vendus\Providers\VendusServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
@@ -27,5 +29,57 @@ abstract class TestCase extends Orchestra
 
         $app['config']->set('vendus.api_key', 'test-api-key');
         $app['config']->set('vendus.app_url', 'https://vendus.test');
+        $app['config']->set('vendus.base_url', 'https://www.vendus.test/ws/v1.1/');
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('vendus_id')->nullable();
+            $table->string('fiscal_id')->nullable();
+            $table->string('name')->nullable();
+            $table->string('address')->nullable();
+            $table->string('city')->nullable();
+            $table->string('postal_code')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('mobile')->nullable();
+            $table->string('email')->nullable();
+            $table->string('website')->nullable();
+            $table->string('country')->nullable();
+            $table->json('price_group')->nullable();
+            $table->string('send_mail')->nullable();
+            $table->string('irs_retention')->nullable();
+            $table->string('status')->nullable();
+            $table->string('notes')->nullable();
+            $table->string('date')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('vendus_id')->nullable();
+            $table->string('reference')->nullable();
+            $table->string('barcode')->nullable();
+            $table->string('supplier_code')->nullable();
+            $table->string('title')->nullable();
+            $table->string('description')->nullable();
+            $table->string('include_description')->nullable();
+            $table->string('supply_price')->nullable();
+            $table->string('gross_price')->nullable();
+            $table->unsignedBigInteger('unit_id')->nullable();
+            $table->string('type_id')->nullable();
+            $table->unsignedInteger('stock_control')->nullable();
+            $table->string('stock_type')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->string('tax_exemption')->nullable();
+            $table->string('tax_exemption_law')->nullable();
+            $table->unsignedBigInteger('category_id')->nullable();
+            $table->unsignedBigInteger('brand_id')->nullable();
+            $table->string('image')->nullable();
+            $table->string('status')->nullable();
+            $table->json('prices')->nullable();
+            $table->timestamps();
+        });
     }
 }

--- a/tests/Unit/EntitiesTest.php
+++ b/tests/Unit/EntitiesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use CodeTech\Vendus\Entities\VendusItem;
+use CodeTech\Vendus\Entities\VendusSalesDocument;
+use CodeTech\Vendus\Entities\VendusStock;
+use CodeTech\Vendus\Entities\VendusTax;
+
+it('defines the sales document types', function () {
+    expect(VendusSalesDocument::TYPE_FT)->toBe('FT')
+        ->and(VendusSalesDocument::TYPE_FS)->toBe('FS')
+        ->and(VendusSalesDocument::TYPE_FR)->toBe('FR')
+        ->and(VendusSalesDocument::TYPE_NC)->toBe('NC')
+        ->and(VendusSalesDocument::TYPE_DC)->toBe('DC')
+        ->and(VendusSalesDocument::TYPE_PF)->toBe('PF')
+        ->and(VendusSalesDocument::TYPE_OT)->toBe('OT')
+        ->and(VendusSalesDocument::TYPE_EC)->toBe('EC')
+        ->and(VendusSalesDocument::TYPE_GA)->toBe('GA')
+        ->and(VendusSalesDocument::TYPE_GT)->toBe('GT')
+        ->and(VendusSalesDocument::TYPE_GR)->toBe('GR')
+        ->and(VendusSalesDocument::TYPE_GD)->toBe('GD')
+        ->and(VendusSalesDocument::TYPE_RG)->toBe('RG');
+});
+
+it('defines the sales document output formats', function () {
+    expect(VendusSalesDocument::OUTPUT_PDF)->toBe('pdf')
+        ->and(VendusSalesDocument::OUTPUT_ESCPOS)->toBe('escpos')
+        ->and(VendusSalesDocument::OUTPUT_HTML)->toBe('html');
+});
+
+it('whitelists the sales document creation params', function () {
+    expect(VendusSalesDocument::CREATE_ALLOWED_PARAMS)
+        ->toBeArray()
+        ->toContain('register_id', 'type', 'date', 'client', 'items', 'payments', 'output', 'external_reference');
+});
+
+it('whitelists the item creation params', function () {
+    expect(VendusItem::CREATE_ALLOWED_PARAMS)
+        ->toBeArray()
+        ->toContain('id', 'reference', 'qty', 'gross_price', 'tax_id', 'discount_percentage');
+});
+
+it('defines the stock types', function () {
+    expect(VendusStock::TYPE_M)->toBe('M')
+        ->and(VendusStock::TYPE_P)->toBe('P')
+        ->and(VendusStock::TYPE_A)->toBe('A')
+        ->and(VendusStock::TYPE_S)->toBe('S')
+        ->and(VendusStock::TYPE_T)->toBe('T');
+});
+
+it('defines the portuguese tax rate codes', function () {
+    expect(VendusTax::TAX_NOR)->toBe('NOR')
+        ->and(VendusTax::TAX_INT)->toBe('INT')
+        ->and(VendusTax::TAX_RED)->toBe('RED')
+        ->and(VendusTax::TAX_ISE)->toBe('ISE')
+        ->and(VendusTax::TAX_OUT)->toBe('OUT');
+});

--- a/tests/Unit/Traits/InteractsWithVendusClientTest.php
+++ b/tests/Unit/Traits/InteractsWithVendusClientTest.php
@@ -22,7 +22,7 @@ it('maps model attributes to vendus client params', function () {
     ]);
     $client->id = 7;
 
-    expect($client->getVendusParams())->toBe([
+    expect($client->getVendusParams())->toEqual([
         'fiscal_id' => '123456789',
         'external_reference' => '7',
         'name' => 'Maria Silva',

--- a/tests/Unit/Traits/InteractsWithVendusClientTest.php
+++ b/tests/Unit/Traits/InteractsWithVendusClientTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use CodeTech\Vendus\Tests\Fixtures\Client;
+
+it('maps model attributes to vendus client params', function () {
+    $client = new Client([
+        'fiscal_id' => '123456789',
+        'name' => 'Maria Silva',
+        'address' => 'Rua das Flores 1',
+        'city' => 'Porto',
+        'postal_code' => '4000-001',
+        'phone' => '220000000',
+        'mobile' => '910000000',
+        'email' => 'maria@example.com',
+        'website' => 'https://example.com',
+        'country' => 'PT',
+        'price_group' => ['id' => 1],
+        'send_mail' => 'yes',
+        'irs_retention' => 'no',
+        'status' => 'active',
+        'notes' => 'VIP',
+    ]);
+    $client->id = 7;
+
+    expect($client->getVendusParams())->toBe([
+        'fiscal_id' => '123456789',
+        'external_reference' => '7',
+        'name' => 'Maria Silva',
+        'address' => 'Rua das Flores 1',
+        'city' => 'Porto',
+        'postalcode' => '4000-001',
+        'phone' => '220000000',
+        'mobile' => '910000000',
+        'email' => 'maria@example.com',
+        'website' => 'https://example.com',
+        'country' => 'PT',
+        'price_group' => ['id' => 1],
+        'send_email' => 'yes',
+        'irs_retention' => 'no',
+        'status' => 'active',
+        'notes' => 'VIP',
+    ]);
+});
+
+it('applies sensible defaults for missing client attributes', function () {
+    $params = (new Client)->getVendusParams();
+
+    expect($params['status'])->toBe('active')
+        ->and($params['send_email'])->toBe('no')
+        ->and($params['price_group'])->toBe([])
+        ->and($params['name'])->toBe('');
+});
+
+it('matches existing vendus clients by external reference', function () {
+    $client = new Client;
+    $client->id = 7;
+
+    expect($client->getVendusFindMatchParams())->toBe(['external_reference' => '7']);
+});
+
+it('uses the clients resource name', function () {
+    expect((new Client)->getVendusResourceName())->toBe('clients');
+});

--- a/tests/Unit/Traits/InteractsWithVendusProductTest.php
+++ b/tests/Unit/Traits/InteractsWithVendusProductTest.php
@@ -27,7 +27,7 @@ it('maps model attributes to vendus product params', function () {
         'prices' => [['group_id' => 1, 'price' => 8.5]],
     ]);
 
-    expect($product->getVendusParams())->toBe([
+    expect($product->getVendusParams())->toEqual([
         'reference' => 'SKU-1',
         'barcode' => '5601234567890',
         'supplier_code' => 'SUP-9',

--- a/tests/Unit/Traits/InteractsWithVendusProductTest.php
+++ b/tests/Unit/Traits/InteractsWithVendusProductTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use CodeTech\Vendus\Entities\VendusStock;
+use CodeTech\Vendus\Tests\Fixtures\Product;
+
+it('maps model attributes to vendus product params', function () {
+    $product = new Product([
+        'reference' => 'SKU-1',
+        'barcode' => '5601234567890',
+        'supplier_code' => 'SUP-9',
+        'title' => 'Vinho Tinto',
+        'description' => 'Douro DOC',
+        'include_description' => 'yes',
+        'supply_price' => '3.50',
+        'gross_price' => '9.99',
+        'unit_id' => 4,
+        'type_id' => 'P',
+        'stock_control' => 1,
+        'stock_type' => VendusStock::TYPE_M,
+        'tax_id' => 'NOR',
+        'tax_exemption' => 'M07',
+        'tax_exemption_law' => 'Artigo 9',
+        'category_id' => 2,
+        'brand_id' => 3,
+        'image' => 'https://example.com/wine.jpg',
+        'status' => 'on',
+        'prices' => [['group_id' => 1, 'price' => 8.5]],
+    ]);
+
+    expect($product->getVendusParams())->toBe([
+        'reference' => 'SKU-1',
+        'barcode' => '5601234567890',
+        'supplier_code' => 'SUP-9',
+        'title' => 'Vinho Tinto',
+        'description' => 'Douro DOC',
+        'include_description' => 'yes',
+        'supply_price' => 3.5,
+        'gross_price' => 9.99,
+        'unit_id' => 4,
+        'type_id' => 'P',
+        'stock_control' => 1,
+        'stock_type' => 'M',
+        'tax_id' => 'NOR',
+        'tax_exemption' => 'M07',
+        'tax_exemption_law' => 'Artigo 9',
+        'category_id' => 2,
+        'brand_id' => 3,
+        'image' => 'https://example.com/wine.jpg',
+        'status' => 'on',
+        'prices' => [['group_id' => 1, 'price' => 8.5]],
+    ]);
+});
+
+it('returns the prices attribute from getVendusPrices', function () {
+    // Regression: this used to read a non-existent `s` property and always
+    // returned an empty array, so price groups were never sent to Vendus.
+    $product = new Product(['prices' => [['group_id' => 1, 'price' => 8.5]]]);
+
+    expect($product->getVendusPrices())->toBe([['group_id' => 1, 'price' => 8.5]]);
+});
+
+it('casts string price attributes to float', function () {
+    $product = new Product(['supply_price' => '12.50', 'gross_price' => '19.90']);
+
+    expect($product->getVendusSupplyPrice())->toBe(12.5)
+        ->and($product->getVendusGrossPrice())->toBe(19.9);
+});
+
+it('applies sensible defaults for missing product attributes', function () {
+    $params = (new Product)->getVendusParams();
+
+    expect($params['include_description'])->toBe('no')
+        ->and($params['supply_price'])->toBe(0.0)
+        ->and($params['gross_price'])->toBe(0.0)
+        ->and($params['type_id'])->toBe('P')
+        ->and($params['stock_control'])->toBe(0)
+        ->and($params['stock_type'])->toBe(VendusStock::TYPE_T)
+        ->and($params['status'])->toBe('on')
+        ->and($params['prices'])->toBe([]);
+});
+
+it('matches existing vendus products by reference', function () {
+    $product = new Product;
+    $product->id = 12;
+
+    expect($product->getVendusFindMatchParams())->toBe(['reference' => '12']);
+});
+
+it('uses the products resource name', function () {
+    expect((new Product)->getVendusResourceName())->toBe('products');
+});

--- a/tests/Unit/Traits/VendusApiResourceTest.php
+++ b/tests/Unit/Traits/VendusApiResourceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use CodeTech\Vendus\Tests\Fixtures\Client;
+
+it('reads the vendus id from the model', function () {
+    expect((new Client)->getVendusId())->toBeNull()
+        ->and((new Client(['vendus_id' => 42]))->getVendusId())->toBe(42);
+});
+
+it('persists the vendus id when set', function () {
+    $client = Client::create(['name' => 'Maria']);
+
+    $client->setVendusId(42);
+
+    expect($client->fresh()->vendus_id)->toBe(42);
+});
+
+it('builds the detail page link from the configured app url', function () {
+    $client = new Client(['vendus_id' => 5]);
+
+    expect($client->getDetailPageLink())->toBe('https://vendus.test/clients/detail/id/5');
+});


### PR DESCRIPTION
## Description

Real behavioral coverage on top of the scaffold — suite grows from 17 to 43 tests (126 assertions):

- **Unit — entities**: document types, output formats, stock types, tax codes, and the `CREATE_ALLOWED_PARAMS` whitelists of `VendusSalesDocument`/`VendusItem`.
- **Unit — traits**: full attribute→param mapping for `InteractsWithVendusClient` (including the `postalcode`/`send_email` key names) and `InteractsWithVendusProduct`, defaults for empty models, find-match params, the `getVendusPrices()` regression test, and string→float price casting. The `VendusApiResource` trait: `vendus_id` read/persist and `getDetailPageLink()` URL building.
- **Feature — VendusResource** end-to-end over `Http::fake()`: the `store()` find-by-reference dedupe path (both branches — create when no match, link+update when Vendus already has the record), `sync()` create-vs-update, `vendus_id` write-back, error propagation with the model left unlinked, `find()` and `get()`.
- **Fixtures**: `tests/Fixtures/Client.php` / `Product.php` — Eloquent models that `use` the traits **and implement the contracts**, so any drift between trait implementations and the interfaces fails compilation loudly. Backing tables created in `TestCase::defineDatabaseMigrations()` (sqlite `:memory:`).
- `vendus.base_url` now pointed at a test host in `TestCase`, so no test can ever touch the real API.

Fixes #9
