### PR TITLE
chore(quality): add Pint code style and Larastan static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
     "illuminate/support": "^11.0|^12.0|^13.0"
   },
   "require-dev": {
+    "larastan/larastan": "^3.10",
+    "laravel/pint": "^1.29",
     "orchestra/testbench": "^9.0|^10.0|^11.0",
     "pestphp/pest": "^3.0|^4.0"
   },
@@ -45,6 +47,9 @@
     }
   },
   "scripts": {
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=1G",
+    "format": "vendor/bin/pint",
+    "lint": "vendor/bin/pint --test",
     "test": "vendor/bin/pest"
   },
   "minimum-stability": "stable",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    paths:
+        - src
+    level: 5

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,13 @@ parameters:
     paths:
         - src
     level: 5
+    ignoreErrors:
+        # Public traits are consumed by host applications, never inside src/.
+        -
+            identifier: trait.unused
+            path: src/Traits/*
+        # Response::object() is annotated as never-null, but json_decode()
+        # returns null for non-JSON error bodies (covered by tests).
+        -
+            identifier: nullsafe.neverNull
+            path: src/Http/Endpoint.php

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}

--- a/src/Entities/VendusItem.php
+++ b/src/Entities/VendusItem.php
@@ -28,5 +28,4 @@ class VendusItem
         'text',
         'serial',
     ];
-
 }

--- a/src/Entities/VendusSalesDocument.php
+++ b/src/Entities/VendusSalesDocument.php
@@ -5,21 +5,35 @@ namespace CodeTech\Vendus\Entities;
 class VendusSalesDocument
 {
     const TYPE_FT = 'FT';
+
     const TYPE_FS = 'FS';
+
     const TYPE_FR = 'FR';
+
     const TYPE_NC = 'NC';
+
     const TYPE_DC = 'DC';
+
     const TYPE_PF = 'PF';
+
     const TYPE_OT = 'OT';
+
     const TYPE_EC = 'EC';
+
     const TYPE_GA = 'GA';
+
     const TYPE_GT = 'GT';
+
     const TYPE_GR = 'GR';
+
     const TYPE_GD = 'GD';
+
     const TYPE_RG = 'RG';
 
     const OUTPUT_PDF = 'pdf';
+
     const OUTPUT_ESCPOS = 'escpos';
+
     const OUTPUT_HTML = 'html';
 
     const CREATE_ALLOWED_PARAMS = [
@@ -56,5 +70,4 @@ class VendusSalesDocument
         'related_document_id',
         'return_qrcode',
     ];
-
 }

--- a/src/Entities/VendusStock.php
+++ b/src/Entities/VendusStock.php
@@ -4,9 +4,13 @@ namespace CodeTech\Vendus\Entities;
 
 class VendusStock
 {
-    const TYPE_M = "M";
-    const TYPE_P = "P";
-    const TYPE_A = "A";
-    const TYPE_S = "S";
-    const TYPE_T = "T";
+    const TYPE_M = 'M';
+
+    const TYPE_P = 'P';
+
+    const TYPE_A = 'A';
+
+    const TYPE_S = 'S';
+
+    const TYPE_T = 'T';
 }

--- a/src/Entities/VendusTax.php
+++ b/src/Entities/VendusTax.php
@@ -5,8 +5,12 @@ namespace CodeTech\Vendus\Entities;
 abstract class VendusTax
 {
     const TAX_NOR = 'NOR';
+
     const TAX_INT = 'INT';
+
     const TAX_RED = 'RED';
+
     const TAX_ISE = 'ISE';
+
     const TAX_OUT = 'OUT';
 }

--- a/src/Http/Endpoint.php
+++ b/src/Http/Endpoint.php
@@ -11,8 +11,7 @@ class Endpoint
     public function __construct(
         protected VendusApi $api,
         protected string $uri
-    ) {
-    }
+    ) {}
 
     /**
      * Find the specified resource.

--- a/src/Http/VendusApi.php
+++ b/src/Http/VendusApi.php
@@ -6,16 +6,13 @@ class VendusApi
 {
     /**
      * The error messages.
-     *
-     * @var array
      */
     private array $errors = [];
 
     public function __construct(
         protected string $apiKey,
         protected string $baseUrl = 'https://www.vendus.pt/ws/v1.1/'
-    ) {
-    }
+    ) {}
 
     /**
      * Get the clients endpoint.

--- a/src/Providers/VendusServiceProvider.php
+++ b/src/Providers/VendusServiceProvider.php
@@ -26,7 +26,7 @@ class VendusServiceProvider extends ServiceProvider
         $this->setPublishableFiles();
 
         // Load translations from custom path
-        $this->loadTranslationsFrom(__DIR__ . '/../../resources/lang', 'vendus');
+        $this->loadTranslationsFrom(__DIR__.'/../../resources/lang', 'vendus');
     }
 
     /**
@@ -35,7 +35,7 @@ class VendusServiceProvider extends ServiceProvider
     private function setConfigurations()
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../../config/vendus.php', 'vendus'
+            __DIR__.'/../../config/vendus.php', 'vendus'
         );
     }
 
@@ -45,11 +45,11 @@ class VendusServiceProvider extends ServiceProvider
     private function setPublishableFiles()
     {
         $this->publishes([
-            __DIR__ . '/../../resources/lang' => $this->app->langPath('vendor/vendus'),
+            __DIR__.'/../../resources/lang' => $this->app->langPath('vendor/vendus'),
         ], 'translations');
 
         $this->publishes([
-            __DIR__ . '/../../config/vendus.php' => config_path('vendus.php'),
+            __DIR__.'/../../config/vendus.php' => config_path('vendus.php'),
         ], 'config');
     }
 }

--- a/src/Traits/InteractsWithVendusClient.php
+++ b/src/Traits/InteractsWithVendusClient.php
@@ -8,176 +8,121 @@ trait InteractsWithVendusClient
 
     /**
      * Returns the Vendus resource name.
-     *
-     * @return string
      */
     public function getVendusResourceName(): string
     {
         return 'clients';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusFiscalId(): string
     {
         return $this->fiscal_id ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusExternalReference(): string
     {
         return $this->id ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusName(): string
     {
         return $this->name ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusAddress(): string
     {
         return $this->address ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusCity(): string
     {
         return $this->city ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusPostalCode(): string
     {
         return $this->postal_code ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusPhone(): string
     {
         return $this->phone ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusMobile(): string
     {
         return $this->mobile ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusEmail(): string
     {
         return $this->email ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusWebsite(): string
     {
         return $this->website ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusCountry(): string
     {
         return $this->country ?? '';
     }
 
-    /**
-     * @return array
-     */
     public function getVendusPriceGroup(): array
     {
         return $this->price_group ?? [];
     }
 
-    /**
-     * @return string
-     */
     public function getVendusSendMail(): string
     {
         return $this->send_mail ?? 'no';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusIrsRetention(): string
     {
         return $this->irs_retention ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusStatus(): string
     {
         return $this->status ?? 'active';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusNotes(): string
     {
         return $this->notes ?? '';
     }
 
-    /**
-     * @return array
-     */
     public function getVendusParams(): array
     {
         return [
-            "fiscal_id" => $this->getVendusFiscalId(),
-            "external_reference" => $this->getVendusExternalReference(),
-            "name" => $this->getVendusName(),
-            "address" => $this->getVendusAddress(),
-            "city" => $this->getVendusCity(),
-            "postalcode" => $this->getVendusPostalCode(),
-            "phone" => $this->getVendusPhone(),
-            "mobile" => $this->getVendusMobile(),
-            "email" => $this->getVendusEmail(),
-            "website" => $this->getVendusWebsite(),
-            "country" => $this->getVendusCountry(),
-            "price_group" => $this->getVendusPriceGroup(),
-            "send_email" => $this->getVendusSendMail(),
-            "irs_retention" => $this->getVendusIrsRetention(),
-            "status" => $this->getVendusStatus(),
-            "notes" => $this->getVendusNotes(),
+            'fiscal_id' => $this->getVendusFiscalId(),
+            'external_reference' => $this->getVendusExternalReference(),
+            'name' => $this->getVendusName(),
+            'address' => $this->getVendusAddress(),
+            'city' => $this->getVendusCity(),
+            'postalcode' => $this->getVendusPostalCode(),
+            'phone' => $this->getVendusPhone(),
+            'mobile' => $this->getVendusMobile(),
+            'email' => $this->getVendusEmail(),
+            'website' => $this->getVendusWebsite(),
+            'country' => $this->getVendusCountry(),
+            'price_group' => $this->getVendusPriceGroup(),
+            'send_email' => $this->getVendusSendMail(),
+            'irs_retention' => $this->getVendusIrsRetention(),
+            'status' => $this->getVendusStatus(),
+            'notes' => $this->getVendusNotes(),
         ];
     }
 
     /**
      * Get the parameters to perform a search to find a matching resource in Vendus.
-     *
-     * @return array
      */
     public function getVendusFindMatchParams(): array
     {
         return [
-            'external_reference' => $this->getVendusExternalReference()
+            'external_reference' => $this->getVendusExternalReference(),
         ];
     }
 }

--- a/src/Traits/InteractsWithVendusProduct.php
+++ b/src/Traits/InteractsWithVendusProduct.php
@@ -10,97 +10,62 @@ trait InteractsWithVendusProduct
 
     /**
      * Returns the Vendus resource name.
-     *
-     * @return string
      */
     public function getVendusResourceName(): string
     {
         return 'products';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusReference(): string
     {
         return $this->reference ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusExternalReference(): string
     {
         return $this->id ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusBarcode(): string
     {
         return $this->barcode ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusSupplierCode(): string
     {
         return $this->supplier_code ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusTitle(): string
     {
         return $this->title ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusDescription(): string
     {
         return $this->description ?? '';
     }
 
-    /**
-     * @return string
-     */
     public function getVendusIncludeDescription(): string
     {
         return $this->include_description ?? 'no';
     }
 
-    /**
-     * @return float
-     */
     public function getVendusSupplyPrice(): float
     {
         return (float) ($this->supply_price ?? 0);
     }
 
-    /**
-     * @return float
-     */
     public function getVendusGrossPrice(): float
     {
         return (float) ($this->gross_price ?? 0);
     }
 
-    /**
-     * @return int
-     */
     public function getVendusUnitId(): ?int
     {
         return $this->unit_id ?? null;
     }
 
-    /**
-     * @return string
-     */
     public function getVendusTypeId(): string
     {
         return $this->type_id ?? 'P';
@@ -116,125 +81,93 @@ trait InteractsWithVendusProduct
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusStockType(): string
     {
         return $this->stock_type ?? VendusStock::TYPE_T;
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusTaxId(): string
     {
         return $this->tax_id ?? '';
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusTaxExemption(): string
     {
         return $this->tax_exemption ?? '';
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusTaxExemptionLaw(): string
     {
         return $this->tax_exemption_law ?? '';
 
     }
 
-    /**
-     * @return int
-     */
     public function getVendusCategoryId(): ?int
     {
         return $this->category_id ?? null;
 
     }
 
-    /**
-     * @return int|null
-     */
     public function getVendusBrandId(): ?int
     {
         return $this->brand_id ?? null;
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusImage(): string
     {
         return $this->image ?? '';
 
     }
 
-    /**
-     * @return string
-     */
     public function getVendusStatus(): string
     {
         return $this->status ?? 'on';
 
     }
 
-    /**
-     * @return array
-     */
     public function getVendusPrices(): array
     {
         return $this->prices ?? [];
 
     }
 
-    /**
-     * @return array
-     */
     public function getVendusParams(): array
     {
         return [
-            "reference" => $this->getVendusReference(),
-            "barcode" => $this->getVendusBarcode(),
-            "supplier_code" => $this->getVendusSupplierCode(),
-            "title" => $this->getVendusTitle(),
-            "description" => $this->getVendusDescription(),
-            "include_description" => $this->getVendusIncludeDescription(),
-            "supply_price" => $this->getVendusSupplyPrice(),
-            "gross_price" => $this->getVendusGrossPrice(),
-            "unit_id" => $this->getVendusUnitId(),
-            "type_id" => $this->getVendusTypeId(),
-            "stock_control" => $this->getVendusStockControl(),
-            "stock_type" => $this->getVendusStockType(),
-            "tax_id" => $this->getVendusTaxId(),
-            "tax_exemption" => $this->getVendusTaxExemption(),
-            "tax_exemption_law" => $this->getVendusTaxExemptionLaw(),
-            "category_id" => $this->getVendusCategoryId(),
-            "brand_id" => $this->getVendusBrandId(),
-            "image" => $this->getVendusImage(),
-            "status" => $this->getVendusStatus(),
-            "prices" => $this->getVendusPrices(),
+            'reference' => $this->getVendusReference(),
+            'barcode' => $this->getVendusBarcode(),
+            'supplier_code' => $this->getVendusSupplierCode(),
+            'title' => $this->getVendusTitle(),
+            'description' => $this->getVendusDescription(),
+            'include_description' => $this->getVendusIncludeDescription(),
+            'supply_price' => $this->getVendusSupplyPrice(),
+            'gross_price' => $this->getVendusGrossPrice(),
+            'unit_id' => $this->getVendusUnitId(),
+            'type_id' => $this->getVendusTypeId(),
+            'stock_control' => $this->getVendusStockControl(),
+            'stock_type' => $this->getVendusStockType(),
+            'tax_id' => $this->getVendusTaxId(),
+            'tax_exemption' => $this->getVendusTaxExemption(),
+            'tax_exemption_law' => $this->getVendusTaxExemptionLaw(),
+            'category_id' => $this->getVendusCategoryId(),
+            'brand_id' => $this->getVendusBrandId(),
+            'image' => $this->getVendusImage(),
+            'status' => $this->getVendusStatus(),
+            'prices' => $this->getVendusPrices(),
         ];
     }
 
     /**
      * Get the parameters to perform a search to find a matching resource in Vendus.
-     *
-     * @return array
      */
     public function getVendusFindMatchParams(): array
     {
         return [
-            'reference' => $this->getVendusExternalReference()
+            'reference' => $this->getVendusExternalReference(),
         ];
     }
 }

--- a/src/Traits/VendusApiResource.php
+++ b/src/Traits/VendusApiResource.php
@@ -6,8 +6,6 @@ trait VendusApiResource
 {
     /**
      * Returns the Vendus resource ID.
-     *
-     * @return int|null
      */
     public function getVendusId(): ?int
     {
@@ -16,8 +14,6 @@ trait VendusApiResource
 
     /**
      * Sets the Vendus resource ID.
-     *
-     * @param int $vendusId
      */
     public function setVendusId(int $vendusId): void
     {
@@ -27,8 +23,6 @@ trait VendusApiResource
 
     /**
      * Returns the Vendus resource date.
-     *
-     * @return string
      */
     public function getVendusDate(): string
     {
@@ -39,6 +33,7 @@ trait VendusApiResource
      * Return the link to the resource's detail page in the Vendus app.
      *
      * @return string
+     *
      * @throws \ReflectionException
      */
     public function getDetailPageLink()

--- a/src/VendusResource.php
+++ b/src/VendusResource.php
@@ -18,11 +18,8 @@ class VendusResource
      */
     protected $vendusApiClient;
 
-
     /**
      * VendusResource constructor.
-     *
-     * @param VendusApiResource $resource
      */
     public function __construct(VendusApiResource $resource)
     {
@@ -42,7 +39,6 @@ class VendusResource
     /**
      * Get a specified resource.
      *
-     * @param array $params
      * @return mixed
      */
     public function find(array $params)
@@ -52,9 +48,6 @@ class VendusResource
 
     /**
      * Get a listing of the resource.
-     *
-     * @param array $params
-     * @return array
      */
     public function get(array $params): array
     {
@@ -64,7 +57,6 @@ class VendusResource
     /**
      * Creates an entity on Vendus.
      *
-     * @return array
      * @throws \Exception
      */
     public function store(): array
@@ -101,8 +93,6 @@ class VendusResource
 
     /**
      * Updates an entity on Vendus.
-     *
-     * @return array
      */
     public function update(): array
     {
@@ -114,7 +104,6 @@ class VendusResource
     /**
      * Syncs an entity with Vendus.
      *
-     * @return array
      * @throws \Exception
      */
     public function sync(): array
@@ -127,7 +116,8 @@ class VendusResource
      *
      * @return array
      */
-    public function getErrors(){
+    public function getErrors()
+    {
         return $this->vendusApiClient->getErrors();
     }
 }

--- a/src/VendusResource.php
+++ b/src/VendusResource.php
@@ -113,10 +113,8 @@ class VendusResource
 
     /**
      * Get errors.
-     *
-     * @return array
      */
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->vendusApiClient->getErrors();
     }

--- a/tests/Feature/VendusResourceTest.php
+++ b/tests/Feature/VendusResourceTest.php
@@ -16,9 +16,7 @@ function fakeVendusApiResource(): VendusApiResource
             return null;
         }
 
-        public function setVendusId(int $vendusId): void
-        {
-        }
+        public function setVendusId(int $vendusId): void {}
 
         public function getVendusResourceName(): string
         {


### PR DESCRIPTION
## Description

The standard CodeTech quality tooling, mirroring laravel-api-logs/laravel-eupago:

- `laravel/pint ^1.29` with `pint.json` → `{"preset": "laravel"}`, plus the one-off formatting pass (12 files touched: quote normalization, phpdoc cleanup, trailing commas, brace positions — no behavioral changes, suite green before and after)
- `larastan/larastan ^3.10` with `phpstan.neon`: level 5 over `src/`, with two documented targeted ignores:
  - `trait.unused` for `src/Traits/*` — the public traits are consumed by host applications, never inside src/ (same ignore as both reference packages)
  - `nullsafe.neverNull` in `Endpoint.php` — Laravel annotates `Response::object()` as never-null, but `json_decode()` returns null for non-JSON error bodies; that exact path is covered by a test, so the nullsafe access is correct and the annotation is what's wrong
- Composer scripts: `analyse`, `format`, `lint` (joining the existing `test`)

`composer lint`, `composer analyse` and `composer test` (43 passed / 126 assertions) all green.

Fixes #10
