### PR TITLE
docs(community): add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thanks for considering contributing to **codetech/laravel-vendus**!
+
+## Which branch?
+
+- **New features and improvements**: target the [`main`](https://github.com/CodeTechAgency/laravel-vendus/tree/main) branch (2.x, Laravel 11–13).
+- **Security fixes for the 1.x line** (Laravel 6–10): open an issue first — 1.x receives security fixes only, released from the latest `v1.1.x` tag. No other changes are accepted there.
+
+## Getting started
+
+```bash
+git clone git@github.com:CodeTechAgency/laravel-vendus.git
+cd laravel-vendus
+composer install
+```
+
+## Running the package locally
+
+The repository ships a `testbench.yaml`, so the [Testbench CLI](https://packages.tools/testbench) can boot the package inside a real Laravel skeleton without creating a host application:
+
+```bash
+cp .env.example .env      # then add your Vendus API key
+vendor/bin/testbench tinker
+```
+
+Inside tinker the container is up and the service provider is registered, so calls hit the real Vendus API with the credentials from `.env` — e.g.:
+
+```php
+(new CodeTech\Vendus\Http\VendusApi(config('vendus.api_key')))->clients()->get()
+```
+
+## Before submitting a pull request
+
+Run the full quality suite locally — CI runs the same checks:
+
+```bash
+composer test      # Pest test suite
+composer lint      # Pint code-style check (run `composer format` to fix)
+composer analyse   # PHPStan static analysis
+```
+
+- Add tests for any change in behaviour. Tests are written with Pest — unit tests live in `tests/Unit`, feature tests in `tests/Feature`.
+- Keep pull requests focused: one feature or fix per PR.
+- Use a [conventional-commit](https://www.conventionalcommits.org) style title, e.g. `fix(product): handle missing barcode`.
+- Reference the related issue in the PR description. If there is no issue yet, please open one first so the change can be discussed.
+
+## Reporting bugs
+
+Open an issue using the bug report template and include the package, Laravel and PHP versions plus the smallest reproduction you can manage.
+
+**Security vulnerabilities must not be reported publicly** — see the [security policy](https://github.com/CodeTechAgency/laravel-vendus/blob/main/SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 2.x | ✅ Active support |
+| 1.x | ⚠️ Security fixes only |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately via [GitHub Security Advisories](https://github.com/CodeTechAgency/laravel-vendus/security/advisories/new). If that is not an option, email the maintainer at jfrosorio@gmail.com.
+
+You will receive a response as soon as possible. Once the issue is confirmed, a fix is prepared for all supported versions and released together with an advisory crediting the reporter (unless you prefer to remain anonymous).


### PR DESCRIPTION
## Description

The community docs from the CodeTech template, adapted to this package:

- **CONTRIBUTING.md**: branch policy (`main` = 2.x active, Laravel 11–13; 1.x = security fixes only, released from `v1.1.x` tags — this package has no long-lived version branches, unlike eupago), getting started, the `vendor/bin/testbench` local-dev flow (tinker example hitting the real API with `.env` credentials; no migrate step — the package has no migrations), the pre-PR quality checklist (`composer test/lint/analyse`), conventional-commit titles, one-fix-per-PR, and bug-report guidance
- **SECURITY.md**: supported-versions table (2.x active / 1.x security-only) and private reporting via GitHub Security Advisories or maintainer email

Also resolves the two forward-referencing README links flagged in the #29 review — merging this PR (before or together with #29) means those links never 404.

Fixes #15
