### PR TITLE
chore(meta): rewrite composer description and keywords for discoverability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,17 @@
 {
   "name": "codetech/laravel-vendus",
-  "description": "Laravel wrapper for the codetech/vendus-api package.",
+  "description": "Vendus (Cegid Vendus) integration for Laravel — sync clients and products, and issue certified invoices and sales documents.",
   "keywords": [
+    "laravel",
     "vendus",
+    "cegid-vendus",
+    "invoicing",
     "faturação",
     "faturas",
     "recibos",
-    "laravel-vendus",
-    "laravel",
-    "codetech"
+    "pos",
+    "portugal",
+    "saft"
   ],
   "authors": [
     {


### PR DESCRIPTION
Closes #16 (composer.json half; the GitHub repo settings are applied directly, no PR needed).

- Description now states the value instead of the implementation: *"Vendus (Cegid Vendus) integration for Laravel — sync clients and products, and issue certified invoices and sales documents."*
- Keywords replaced with the agreed list: `laravel`, `vendus`, `cegid-vendus`, `invoicing`, `faturação`, `faturas`, `recibos`, `pos`, `portugal`, `saft` (drops the redundant `laravel-vendus`/`codetech`).
- Structure already matched laravel-eupago's reviewed composer.json, so no other changes.

The `cegid-vendus` keyword is metadata-only for search discoverability — package name, namespaces and branding stay Vendus.