### PR TITLE
docs(site): add docs folder for codetech.pt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,64 @@
+---
+title: Configuration
+weight: 4
+group: Getting started
+---
+
+The package is configured through environment variables (see `config/vendus.php`):
+
+```ini
+VENDUS_API_KEY=your-api-key
+VENDUS_APP_URL=https://www.vendus.pt
+VENDUS_MODE=tests
+VENDUS_BASE_URL=https://www.vendus.pt/ws/v1.1/
+```
+
+## API key
+
+`VENDUS_API_KEY` is the only required setting — every request against the Vendus
+API is authenticated with it. You can find it in the Vendus backoffice under your
+account's integration settings. If it is missing, `VendusResource` fails loudly
+with an `InvalidArgumentException` instead of firing unauthenticated requests.
+
+## App URL
+
+`VENDUS_APP_URL` is the URL you use to access the Vendus web application. It is
+only used by `getDetailPageLink()` to build links from your application straight
+to a synced record's detail page in the Vendus backoffice:
+
+```php
+$customer->getDetailPageLink();
+// https://www.vendus.pt/clients/detail/id/123
+```
+
+## Mode
+
+Vendus can register sales documents in two modes: `normal` (real, certified
+documents) and `tests` (draft documents that are not certified nor communicated
+to the tax authority). The config value — `tests` by default, so a fresh install
+can never issue real invoices by accident — is yours to pass when
+[creating documents](sales-documents.md):
+
+```php
+'mode' => config('vendus.mode'),
+```
+
+Set `VENDUS_MODE=normal` in production.
+
+## Base URL
+
+`VENDUS_BASE_URL` points at Vendus API v1.1 by default. You will rarely need to
+change it — it exists so the client can be pointed at a different API version or
+host without touching code.
+
+## Publishing the config file
+
+To tweak the configuration beyond what the environment variables cover, publish
+the config file:
+
+```bash
+php artisan vendor:publish --provider="CodeTech\Vendus\Providers\VendusServiceProvider" --tag=config
+```
+
+The package also ships [translations](translations.md), publishable with the
+`translations` tag.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: v2
+slogan: Sync clients and products with Vendus, and issue certified Portuguese invoices and sales documents from Laravel
+githubUrl: https://github.com/CodeTechAgency/laravel-vendus
+branch: main
+---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,23 @@
+---
+title: Installation
+weight: 3
+group: Getting started
+---
+
+Add the package to your Laravel application using Composer:
+
+```bash
+composer require codetech/laravel-vendus
+```
+
+The service provider is registered automatically through Laravel's package
+discovery — there is nothing to add to your application.
+
+Set your API key in `.env` and you are ready to go:
+
+```ini
+VENDUS_API_KEY=your-api-key
+```
+
+All settings — and the optional publishing of the config file and translations —
+are covered in [Configuration](configuration.md).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,50 @@
+---
+title: Introduction
+weight: 1
+group: Getting started
+---
+
+[Vendus](https://www.vendus.pt) (Cegid Vendus) is a Portuguese certified invoicing
+and POS software. This package connects it to Laravel:
+
+- **Sync Eloquent models** — customers, products — with your Vendus account through
+  a pair of drop-in traits. Create, update, or let the package figure out which of
+  the two is needed with a single `sync()` call.
+- **Issue certified sales documents** — invoices, receipts, credit notes, transport
+  guides — through a clean HTTP client, with the document types, item parameters,
+  stock types, and tax codes exposed as constants.
+- **Translate the domain** — the package ships English and Portuguese strings for
+  document types, payment statuses, and sync feedback messages.
+
+Because the HTTP layer is built on Laravel's HTTP client, the entire integration can
+be faked in your tests with `Http::fake()` — no real API calls, no mocking gymnastics.
+
+## Architecture
+
+The package is organized in three layers, from your models down to the wire:
+
+- **Contracts** (`VendusApiResource`, `VendusClient`, `VendusProduct`) declare the
+  data a syncable model must expose — its Vendus ID, the attribute values, and the
+  parameters used to match it against existing Vendus records.
+- **Traits** (`InteractsWithVendusClient`, `InteractsWithVendusProduct`) implement
+  those contracts with sensible defaults that read conventional column names
+  (`name`, `email`, `reference`, `gross_price`, …). Override any getter to map your
+  own schema.
+- **`VendusResource`** wraps a model implementing a contract and performs the API
+  operations — `find`, `get`, `store`, `update`, and `sync` — through the underlying
+  **`VendusApi`** client, which exposes the `clients`, `products`, `products/units`,
+  `documents`, and `documents/paymentmethods` endpoints.
+
+A typical sync is three lines:
+
+```php
+use CodeTech\Vendus\VendusResource;
+
+$customer = Customer::find(1);
+
+(new VendusResource($customer))->sync();
+```
+
+Continue with the [requirements](requirements.md) and
+[installation](installation.md), then follow the
+[clients](syncing-clients.md) and [products](syncing-products.md) walkthroughs.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -35,14 +35,15 @@ The package is organized in three layers, from your models down to the wire:
   **`VendusApi`** client, which exposes the `clients`, `products`, `products/units`,
   `documents`, and `documents/paymentmethods` endpoints.
 
-A typical sync is three lines:
+A typical sync is a handful of lines:
 
 ```php
 use CodeTech\Vendus\VendusResource;
 
 $customer = Customer::find(1);
 
-(new VendusResource($customer))->sync();
+$resource = new VendusResource($customer);
+$resource->sync();
 ```
 
 Continue with the [requirements](requirements.md) and

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,17 @@
+---
+title: Requirements
+weight: 2
+group: Getting started
+---
+
+| Package version | Laravel | PHP                          | Status         |
+|-----------------|---------|------------------------------|----------------|
+| 2.x (`main`)    | 11 – 13 | ≥ 8.2 (≥ 8.3 for Laravel 13) | Active         |
+| 1.x             | 6 – 10  | ≥ 7.3                        | Security fixes |
+
+Upgrading from 1.x? Follow the
+[upgrade guide](https://github.com/CodeTechAgency/laravel-vendus/blob/main/UPGRADE.md).
+
+You will also need a [Vendus](https://www.vendus.pt) account and its **API key**,
+which you can find in the Vendus backoffice under your account's integration
+settings. See [Configuration](configuration.md).

--- a/docs/sales-documents.md
+++ b/docs/sales-documents.md
@@ -1,0 +1,117 @@
+---
+title: Sales documents
+weight: 7
+group: Usage
+---
+
+Sales documents — invoices, receipts, credit notes, transport guides — are issued
+through the `VendusApi` client directly. Unlike clients and products, documents
+are immutable certified records, so there is no trait or sync flow: you build the
+payload and create the document.
+
+```php
+use CodeTech\Vendus\Entities\VendusSalesDocument;
+use CodeTech\Vendus\Http\VendusApi;
+
+$api = new VendusApi(config('vendus.api_key'));
+
+$document = $api->documents()->create([
+    'type' => VendusSalesDocument::TYPE_FT,
+    'mode' => config('vendus.mode'),
+    'client' => [
+        'id' => $customer->getVendusId(),
+    ],
+    'items' => [
+        [
+            'id' => $product->getVendusId(),
+            'qty' => 2,
+        ],
+    ],
+    'output' => VendusSalesDocument::OUTPUT_PDF,
+]);
+```
+
+Keep `mode` bound to [the config value](configuration.md#mode) — `tests` creates
+draft documents that are neither certified nor communicated to the tax authority,
+`normal` creates the real thing.
+
+Besides `documents()`, the client exposes the `clients()`, `products()`,
+`units()`, and `paymentMethods()` endpoints, each with `find`, `get`, `paginate`,
+`create`, and `update` methods.
+
+## Document types
+
+The `VendusSalesDocument` constants cover the Vendus document types:
+
+| Constant  | Value | Document                                        |
+|-----------|-------|-------------------------------------------------|
+| `TYPE_FT` | `FT`  | Fatura — invoice                                |
+| `TYPE_FS` | `FS`  | Fatura Simplificada — simplified invoice        |
+| `TYPE_FR` | `FR`  | Fatura-Recibo — invoice/receipt                 |
+| `TYPE_NC` | `NC`  | Nota de Crédito — credit note                   |
+| `TYPE_RG` | `RG`  | Recibo — receipt                                |
+| `TYPE_PF` | `PF`  | Fatura Pró-Forma — proforma invoice             |
+| `TYPE_OT` | `OT`  | Orçamento — quotation                           |
+| `TYPE_EC` | `EC`  | Encomenda — customer order                      |
+| `TYPE_DC` | `DC`  | Consulta de Mesa — table check (POS)            |
+| `TYPE_GT` | `GT`  | Guia de Transporte — transport guide            |
+| `TYPE_GR` | `GR`  | Guia de Remessa — shipping guide                |
+| `TYPE_GD` | `GD`  | Guia de Devolução — return guide                |
+| `TYPE_GA` | `GA`  | Guia de Ativos Próprios — own assets guide      |
+
+## Output formats
+
+Ask Vendus to render the document by passing `output`:
+
+| Constant        | Value    | Result                          |
+|-----------------|----------|---------------------------------|
+| `OUTPUT_PDF`    | `pdf`    | PDF document                    |
+| `OUTPUT_ESCPOS` | `escpos` | ESC/POS payload for printers    |
+| `OUTPUT_HTML`   | `html`   | HTML document                   |
+
+## Allowed parameters
+
+`VendusSalesDocument::CREATE_ALLOWED_PARAMS` lists every parameter the documents
+endpoint accepts on creation — `register_id`, `payments`, `date_due`,
+`movement_of_goods`, `invoices`, and so on — and
+`VendusItem::CREATE_ALLOWED_PARAMS` does the same for each entry of `items`
+(`qty`, `gross_price`, `discount_percentage`, `tax_id`, …). Use them to whitelist
+user-provided input before it reaches the API:
+
+```php
+use CodeTech\Vendus\Entities\VendusSalesDocument;
+use Illuminate\Support\Arr;
+
+$params = Arr::only($input, VendusSalesDocument::CREATE_ALLOWED_PARAMS);
+```
+
+## Reading documents
+
+`get()` lists documents with any filter the API accepts, and `find()` fetches a
+single one — including its rendered output:
+
+```php
+$invoices = $api->documents()->get(['type' => VendusSalesDocument::TYPE_FT]);
+
+$document = $api->documents()->find($id, ['output' => VendusSalesDocument::OUTPUT_PDF]);
+```
+
+For large listings, `paginate()` returns a page of results plus the total count
+reported by the API:
+
+```php
+['data' => $documents, 'total' => $total] = $api->documents()->paginate([], page: 1, perPage: 50);
+```
+
+## Error handling
+
+Failed creates throw an `Illuminate\Http\Client\RequestException`; the parsed
+Vendus error messages are available on the client:
+
+```php
+try {
+    $api->documents()->create($params);
+} catch (RequestException $e) {
+    $errors = $api->getErrors(); // ['field' => 'code: message', …]
+}
+```

--- a/docs/sales-documents.md
+++ b/docs/sales-documents.md
@@ -13,7 +13,7 @@ payload and create the document.
 use CodeTech\Vendus\Entities\VendusSalesDocument;
 use CodeTech\Vendus\Http\VendusApi;
 
-$api = new VendusApi(config('vendus.api_key'));
+$api = new VendusApi(config('vendus.api_key'), config('vendus.base_url'));
 
 $document = $api->documents()->create([
     'type' => VendusSalesDocument::TYPE_FT,

--- a/docs/syncing-clients.md
+++ b/docs/syncing-clients.md
@@ -1,0 +1,124 @@
+---
+title: Syncing clients
+weight: 5
+group: Usage
+---
+
+Any Eloquent model can be synced with Vendus' `clients` resource — a `Customer`,
+a `Company`, a `User`. The model needs three things: a `vendus_id` column, the
+`VendusClient` contract, and the `InteractsWithVendusClient` trait.
+
+## Prepare the model
+
+Add the column that will store the Vendus ID:
+
+```php
+Schema::table('customers', function (Blueprint $table) {
+    $table->unsignedBigInteger('vendus_id')->nullable();
+});
+```
+
+Then implement the contract using the trait:
+
+```php
+use CodeTech\Vendus\Contracts\VendusClient;
+use CodeTech\Vendus\Traits\InteractsWithVendusClient;
+use Illuminate\Database\Eloquent\Model;
+
+class Customer extends Model implements VendusClient
+{
+    use InteractsWithVendusClient;
+}
+```
+
+## Attribute mapping
+
+The trait satisfies the contract by reading conventional column names. Each value
+is exposed through a getter, and the full payload sent to Vendus is assembled by
+`getVendusParams()`:
+
+| Getter                        | Reads                | Sent as              | Default    |
+|-------------------------------|----------------------|----------------------|------------|
+| `getVendusFiscalId()`         | `$this->fiscal_id`   | `fiscal_id`          | `''`       |
+| `getVendusExternalReference()`| `$this->id`          | `external_reference` | `''`       |
+| `getVendusName()`             | `$this->name`        | `name`               | `''`       |
+| `getVendusAddress()`          | `$this->address`     | `address`            | `''`       |
+| `getVendusCity()`             | `$this->city`        | `city`               | `''`       |
+| `getVendusPostalCode()`       | `$this->postal_code` | `postalcode`         | `''`       |
+| `getVendusPhone()`            | `$this->phone`       | `phone`              | `''`       |
+| `getVendusMobile()`           | `$this->mobile`      | `mobile`             | `''`       |
+| `getVendusEmail()`            | `$this->email`       | `email`              | `''`       |
+| `getVendusWebsite()`          | `$this->website`     | `website`            | `''`       |
+| `getVendusCountry()`          | `$this->country`     | `country`            | `''`       |
+| `getVendusPriceGroup()`       | `$this->price_group` | `price_group`        | `[]`       |
+| `getVendusSendMail()`         | `$this->send_mail`   | `send_email`         | `'no'`     |
+| `getVendusIrsRetention()`     | `$this->irs_retention` | `irs_retention`    | `''`       |
+| `getVendusStatus()`           | `$this->status`      | `status`             | `'active'` |
+| `getVendusNotes()`            | `$this->notes`       | `notes`              | `''`       |
+
+If your schema uses different names, override the getter — the trait's
+`getVendusParams()` picks the change up automatically:
+
+```php
+public function getVendusFiscalId(): string
+{
+    return $this->nif ?? '';
+}
+```
+
+## Syncing
+
+Wrap the model in a `VendusResource` and call `sync()`:
+
+```php
+use CodeTech\Vendus\VendusResource;
+
+(new VendusResource($customer))->sync();
+```
+
+`sync()` decides what to do based on the local `vendus_id`:
+
+- **No `vendus_id` yet** — the package first searches Vendus for a client whose
+  `external_reference` matches the model's ID (see `getVendusFindMatchParams()`).
+  If one exists, its ID is adopted and the record is updated; otherwise the client
+  is created. Either way, the resulting Vendus ID is saved on your model.
+- **`vendus_id` present** — the Vendus record is updated with the current
+  attribute values.
+
+You can also call `store()` or `update()` directly when you know which operation
+you want.
+
+## Reading from Vendus
+
+The same `VendusResource` reads back from the API — `find()` fetches the wrapped
+model's Vendus record, `get()` lists clients with any filter the API accepts:
+
+```php
+$resource = new VendusResource($customer);
+
+$vendusClient = $resource->find([]);
+$matches = $resource->get(['fiscal_id' => '123456789']);
+```
+
+## Error handling
+
+When Vendus rejects a create or update, an
+`Illuminate\Http\Client\RequestException` is thrown and the API's error messages
+are collected for inspection:
+
+```php
+try {
+    (new VendusResource($customer))->sync();
+} catch (RequestException $e) {
+    $errors = $resource->getErrors(); // ['field' => 'code: message', …]
+}
+```
+
+## Linking to the Vendus backoffice
+
+Once synced, `getDetailPageLink()` returns the record's detail page URL in the
+Vendus web app — handy for back-office UIs:
+
+```php
+<a href="{{ $customer->getDetailPageLink() }}">{{ __('vendus::messages.vendus') }}</a>
+```

--- a/docs/syncing-clients.md
+++ b/docs/syncing-clients.md
@@ -107,8 +107,10 @@ When Vendus rejects a create or update, an
 are collected for inspection:
 
 ```php
+$resource = new VendusResource($customer);
+
 try {
-    (new VendusResource($customer))->sync();
+    $resource->sync();
 } catch (RequestException $e) {
     $errors = $resource->getErrors(); // ['field' => 'code: message', …]
 }

--- a/docs/syncing-clients.md
+++ b/docs/syncing-clients.md
@@ -73,7 +73,8 @@ Wrap the model in a `VendusResource` and call `sync()`:
 ```php
 use CodeTech\Vendus\VendusResource;
 
-(new VendusResource($customer))->sync();
+$resource = new VendusResource($customer);
+$resource->sync();
 ```
 
 `sync()` decides what to do based on the local `vendus_id`:

--- a/docs/syncing-products.md
+++ b/docs/syncing-products.md
@@ -1,0 +1,118 @@
+---
+title: Syncing products
+weight: 6
+group: Usage
+---
+
+Products follow the exact same pattern as [clients](syncing-clients.md): a
+`vendus_id` column, the `VendusProduct` contract, and the
+`InteractsWithVendusProduct` trait.
+
+```php
+use CodeTech\Vendus\Contracts\VendusProduct;
+use CodeTech\Vendus\Traits\InteractsWithVendusProduct;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model implements VendusProduct
+{
+    use InteractsWithVendusProduct;
+}
+```
+
+```php
+use CodeTech\Vendus\VendusResource;
+
+(new VendusResource($product))->sync();
+```
+
+## Attribute mapping
+
+| Getter                         | Reads                     | Sent as             | Default              |
+|--------------------------------|---------------------------|---------------------|----------------------|
+| `getVendusReference()`         | `$this->reference`        | `reference`         | `''`                 |
+| `getVendusBarcode()`           | `$this->barcode`          | `barcode`           | `''`                 |
+| `getVendusSupplierCode()`      | `$this->supplier_code`    | `supplier_code`     | `''`                 |
+| `getVendusTitle()`             | `$this->title`            | `title`             | `''`                 |
+| `getVendusDescription()`       | `$this->description`      | `description`       | `''`                 |
+| `getVendusIncludeDescription()`| `$this->include_description` | `include_description` | `'no'`          |
+| `getVendusSupplyPrice()`       | `$this->supply_price`     | `supply_price`      | `0`                  |
+| `getVendusGrossPrice()`        | `$this->gross_price`      | `gross_price`       | `0`                  |
+| `getVendusUnitId()`            | `$this->unit_id`          | `unit_id`           | `null`               |
+| `getVendusTypeId()`            | `$this->type_id`          | `type_id`           | `'P'`                |
+| `getVendusStockControl()`      | `$this->stock_control`    | `stock_control`     | `0`                  |
+| `getVendusStockType()`         | `$this->stock_type`       | `stock_type`        | `VendusStock::TYPE_T`|
+| `getVendusTaxId()`             | `$this->tax_id`           | `tax_id`            | `''`                 |
+| `getVendusTaxExemption()`      | `$this->tax_exemption`    | `tax_exemption`     | `''`                 |
+| `getVendusTaxExemptionLaw()`   | `$this->tax_exemption_law`| `tax_exemption_law` | `''`                 |
+| `getVendusCategoryId()`        | `$this->category_id`      | `category_id`       | `null`               |
+| `getVendusBrandId()`           | `$this->brand_id`         | `brand_id`          | `null`               |
+| `getVendusImage()`             | `$this->image`            | `image`             | `''`                 |
+| `getVendusStatus()`            | `$this->status`           | `status`            | `'on'`               |
+| `getVendusPrices()`            | `$this->prices`           | `prices`            | `[]`                 |
+
+As with clients, override any getter to map your own schema.
+
+## Matching existing products
+
+When a model has no `vendus_id`, `sync()` first looks for an existing Vendus
+product before creating one. By default the lookup searches by `reference` using
+the model's ID (its external reference):
+
+```php
+public function getVendusFindMatchParams(): array
+{
+    return [
+        'reference' => $this->getVendusExternalReference(),
+    ];
+}
+```
+
+If your `reference` column holds something other than the model's ID, override
+`getVendusFindMatchParams()` so the match uses the same value you send:
+
+```php
+public function getVendusFindMatchParams(): array
+{
+    return [
+        'reference' => $this->getVendusReference(),
+    ];
+}
+```
+
+## Product types
+
+`type_id` classifies the product for SAF-T purposes:
+
+| Value | Meaning                                                  |
+|-------|----------------------------------------------------------|
+| `P`   | Product (default)                                        |
+| `S`   | Service                                                  |
+| `O`   | Other — shipping, advances, etc.                         |
+| `I`   | Tax other than VAT and stamp duty, or parafiscal charge  |
+| `E`   | Special consumption tax — IABA, ISP, IT                  |
+
+## Stock types
+
+The `CodeTech\Vendus\Entities\VendusStock` constants cover the allowed
+`stock_type` values:
+
+| Constant             | Value | Meaning                                       |
+|----------------------|-------|-----------------------------------------------|
+| `VendusStock::TYPE_M`| `M`   | Merchandise                                   |
+| `VendusStock::TYPE_P`| `P`   | Raw, subsidiary, and consumable materials     |
+| `VendusStock::TYPE_A`| `A`   | Finished and intermediate products            |
+| `VendusStock::TYPE_S`| `S`   | By-products, waste, and scrap                 |
+| `VendusStock::TYPE_T`| `T`   | Products and work in progress (default)       |
+
+## Tax codes
+
+The `CodeTech\Vendus\Entities\VendusTax` constants cover the Portuguese VAT
+classes accepted in `tax_id`:
+
+| Constant              | Value  | Meaning                                          |
+|-----------------------|--------|--------------------------------------------------|
+| `VendusTax::TAX_NOR`  | `NOR`  | Normal rate                                      |
+| `VendusTax::TAX_INT`  | `INT`  | Intermediate rate                                |
+| `VendusTax::TAX_RED`  | `RED`  | Reduced rate                                     |
+| `VendusTax::TAX_ISE`  | `ISE`  | Exempt — requires `tax_exemption` and `tax_exemption_law` |
+| `VendusTax::TAX_OUT`  | `OUT`  | Other                                            |

--- a/docs/syncing-products.md
+++ b/docs/syncing-products.md
@@ -22,7 +22,8 @@ class Product extends Model implements VendusProduct
 ```php
 use CodeTech\Vendus\VendusResource;
 
-(new VendusResource($product))->sync();
+$resource = new VendusResource($product);
+$resource->sync();
 ```
 
 ## Attribute mapping

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,44 @@
+---
+title: Translations
+weight: 8
+group: Usage
+---
+
+The package ships translation strings for the Vendus domain — document types,
+payment statuses, and sync feedback messages — in English and Portuguese, under
+the `vendus::messages` namespace:
+
+```php
+__('vendus::messages.record_synced_success');
+// en: The record has been successfully synced with Vendus!
+// pt: O recurso foi sincronizado com o Vendus com sucesso!
+```
+
+Plural forms use Laravel's standard pluralization:
+
+```php
+trans_choice('vendus::messages.payments', 2);
+// en: Payments — pt: Pagamentos
+```
+
+## Available strings
+
+- **Document types** — `ft` (Invoice), `fr` (Invoice Receipt), `rg` (Receipt),
+  `pf` (Proforma Invoice), `ot` (Quotation). Handy for labelling documents by
+  their type code: `__('vendus::messages.'.strtolower($document['type']))`.
+- **Payment status** — `paid`, `not_paid`.
+- **Sync feedback** — `record_created_success`, `record_updated_success`,
+  `record_deleted_success`, `record_synced_success`, `not_yet_synced`.
+- **UI labels** — `vendus`, `synchronize`, `payments`, `sales_documents`,
+  `related_documents`, `related_record_confirm_create`.
+
+## Customizing
+
+Publish the language files to override any string or add locales:
+
+```bash
+php artisan vendor:publish --provider="CodeTech\Vendus\Providers\VendusServiceProvider" --tag=translations
+```
+
+The files land in `lang/vendor/vendus/{locale}/messages.php`, and Laravel gives
+them precedence over the package's own copies.


### PR DESCRIPTION
Closes #14.

Adds the `docs/` folder consumed by codetech.pt, following the laravel-eupago / laravel-api-logs conventions (`index.md` with `slogan`/`githubUrl`/`branch`; pages with `title`/`weight`/`group` frontmatter). Two sidebar groups: **Getting started** (introduction, requirements, installation, configuration) and **Usage** (syncing-clients, syncing-products, sales-documents, translations).

Content notes:
- Attribute-mapping tables for both traits document the conventional column each getter reads, the API parameter it is sent as, and its default — including the non-obvious `postal_code` → `postalcode` and `send_mail` → `send_email` mappings.
- The products page documents the default find-match quirk (searches by `reference` using the model's ID) and shows how to override `getVendusFindMatchParams()`.
- Document types, product `type_id`, stock types and tax codes were verified against the official Cegid Vendus API docs (`vendus.pt/ws/v1.1/documents/types.doc`, `products.doc`).
- The configuration page documents that `VENDUS_MODE` is a value for you to pass when creating documents (the package never sends it implicitly), defaulting to `tests` so a fresh install can't issue certified documents by accident.
- `/docs export-ignore` was already in `.gitattributes` from #20, so no packaging change needed.

No release tag — docs only.