### PR TITLE
docs(readme): assign VendusResource to a variable in the quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ use CodeTech\Vendus\VendusResource;
 
 $customer = Customer::find(1);
 
-(new VendusResource($customer))->sync();
+$resource = new VendusResource($customer);
+$resource->sync();
 ```
 
 `sync()` creates the customer on Vendus (or updates it if it already exists — clients


### PR DESCRIPTION
Closes #35.

Aligns the README quick start with the docs pages (#34), which declare a `$resource` variable instead of the inline `(new VendusResource(...))->sync()` call.