### PR TITLE
fix: keep docs/ in git archives for the site docs importer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,6 @@
 /.gitignore export-ignore
 /.idea export-ignore
 /art export-ignore
-/docs export-ignore
 /tests export-ignore
 /phpunit.xml export-ignore
 /phpstan.neon export-ignore


### PR DESCRIPTION
Removes the `/docs export-ignore` rule. GitHub's branch tarballs are built with `git archive`, which honors `export-ignore`, so the docs folder never reached the codetech.pt docs importer and `php artisan docs:import` failed with "docs/ contains no pages besides index.md".

Matches laravel-eupago, which ships its docs in archives and imports correctly. Cost is a few KB in Composer dist installs.

Closes #37