### PR TITLE
docs(configuration): correct APP_URL and BASE_URL explanations

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ The package is configured through environment variables (see `config/vendus.php`
 
 ```ini
 VENDUS_API_KEY=your-api-key
-VENDUS_APP_URL=https://www.vendus.pt
+VENDUS_APP_URL=https://your-account.vendus.pt
 VENDUS_MODE=tests
 VENDUS_BASE_URL=https://www.vendus.pt/ws/v1.1/
 ```
@@ -22,13 +22,15 @@ with an `InvalidArgumentException` instead of firing unauthenticated requests.
 
 ## App URL
 
-`VENDUS_APP_URL` is the URL you use to access the Vendus web application. It is
-only used by `getDetailPageLink()` to build links from your application straight
-to a synced record's detail page in the Vendus backoffice:
+`VENDUS_APP_URL` is the URL you use to access the Vendus web application. Every
+Vendus account lives on its own subdomain (e.g. `https://your-account.vendus.pt`),
+so this value is account-specific — there is no global default. It is only used
+by `getDetailPageLink()` to build links from your application straight to a
+synced record's detail page in the Vendus backoffice:
 
 ```php
 $customer->getDetailPageLink();
-// https://www.vendus.pt/clients/detail/id/123
+// https://your-account.vendus.pt/clients/detail/id/123
 ```
 
 ## Mode
@@ -48,8 +50,11 @@ Set `VENDUS_MODE=normal` in production.
 ## Base URL
 
 `VENDUS_BASE_URL` points at Vendus API v1.1 by default. You will rarely need to
-change it — it exists so the client can be pointed at a different API version or
-host without touching code.
+change it — the client is written against v1.1, so pointing it at a different
+API version is not supported. The override exists for two reasons: Vendus serves
+the same API on country-specific hosts (e.g. `https://www.vendus.cv/ws/v1.1/`
+for Cape Verde accounts), and test suites can point the client at a fake host so
+no real API calls are ever made.
 
 ## Publishing the config file
 


### PR DESCRIPTION
Closes #39.

- **App URL**: example and prose now show the per-account subdomain (`https://your-account.vendus.pt`) and state the value is account-specific with no global default.
- **Base URL**: replaces the misleading "different API version" rationale — the client is written against v1.1, so version switching via URL is not supported. Documents the actual reasons the override exists: country-specific hosts (the same v1.1 API is served on e.g. `https://www.vendus.cv/ws/v1.1/`) and pointing tests at a fake host.